### PR TITLE
bump version to 1.0.5

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -14,7 +14,7 @@ program
   .name("commitaai")
   .description("Generate AI-crafted commit messages")
   // .option("-g, --generate", "Generate a commit message")
-  .version("1.0.4");
+  .version("1.0.5");
 
 program.addCommand(generateCommand);
 program.addCommand(configureCommand)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "whatwg-url": "^14.1.1",
     "winston": "^3.17.0"
   },
-  "version": "1.0.4",
+  "version": "1.0.5",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
- Updated the version number in the CLI entry point from 1.0.4 to 1.0.5
- Revised package.json version to reflect the new release version